### PR TITLE
Fast vehicle despawns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ smss.json
 stop
 stop.txt
 temp/
+latest_release
+local_release
+smss_download.py

--- a/smss.py
+++ b/smss.py
@@ -1,5 +1,4 @@
 from bs4 import BeautifulSoup 
-from collections import OrderedDict
 from colorama import init
 from copy import deepcopy
 from datetime import date, datetime
@@ -157,6 +156,7 @@ class SmssConfig:
         self.add_clan_members_for_timer_resets()
         self.reset_base_timers()
         self.reset_tent_timers()
+        self.quick_vehicle_despawn()
         self.reset_vehicle_timers()
         
 
@@ -660,6 +660,16 @@ class SmssConfig:
 
         sql = "UPDATE Structures SET AbandonTimer=2419200 WHERE StructureID IN ({});"
         self.reset_base_object_timers(tents, self.reset_tent_owner_ids, sql, 'tent')
+
+
+    def quick_vehicle_despawn(self):
+        """Reset vehicle timers for quick despawns after restart
+        """
+        quick_vehicle_despawn = int(self.config.get('quick_vehicle_despawn', False))
+        if quick_vehicle_despawn:
+            sql = f"UPDATE Vehicles SET AbandonTimer={quick_vehicle_despawn};"
+            self.get_result_set(sql)
+            return
 
 
     def reset_vehicle_timers(self):


### PR DESCRIPTION
Add option to reset vehicle despawn timer on server restart - this may be used to force more frequent respawns. This option is compatible with the option for extending vehicle despawn timers at defined bases.